### PR TITLE
Set value to null if no key present in input

### DIFF
--- a/sentinelone_model.php
+++ b/sentinelone_model.php
@@ -58,7 +58,7 @@ class Sentinelone_model extends \Model
                     $this->$item = $plist[$search];
                 }
             } else {
-                $this->$item = '';
+                $this->$item = null;
             }
         }
         $this->id = '';


### PR DESCRIPTION
Changed line 61 to record a null value for keys that don't exist in the incoming data.
Previously uploads would error if a boolean was attempted to be set to `''`.